### PR TITLE
Downgrade PyTorch for Vertex AI

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -163,9 +163,9 @@ dependencies:
       - nvidia-nvtx-cu12==12.4.127
       - pillow==11.1.0
       - sympy==1.13.1
-      - torch==2.6.0
-      - torchaudio==2.6.0
-      - torchvision==0.21.0
+      - torch==2.4.0
+      - torchaudio==2.4.0
+      - torchvision==0.19.0
       - triton==3.2.0
       - typing-extensions==4.13.1
 prefix: /home/lordphone/miniconda3/envs/ml


### PR DESCRIPTION
## Summary
- update PyTorch packages in `environment.yml` to 2.4 series

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_6848cc787cd8832793cd3a364239ae25