### PR TITLE
Add directory options to training CLI

### DIFF
--- a/scripts/run_training.sh
+++ b/scripts/run_training.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Example script to run training with configurable directories.
+# Update the paths below with your Google Cloud Storage bucket paths or
+# local directories as needed.
+
+DATASET_PATH="/path/to/dataset"
+CHECKPOINT_DIR="/path/to/checkpoints"
+MODEL_DIR="/path/to/models"
+LOG_DIR="/path/to/logs"
+
+python3 -m src.training.train \
+  --mode train \
+  --dataset-path "$DATASET_PATH" \
+  --checkpoint-dir "$CHECKPOINT_DIR" \
+  --model-dir "$MODEL_DIR" \
+  --log-dir "$LOG_DIR" \
+  "$@"

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -25,17 +25,17 @@ from src.data.video_window_dataset import VideoWindowIterableDataset
 from collections import OrderedDict
 import src.utils.data_utils as data_utils
 
-def setup_logging():
+def setup_logging(log_dir="logs"):
     """Initialize logging configuration."""
     # Ensure logs directory exists
-    os.makedirs("logs", exist_ok=True)
+    os.makedirs(log_dir, exist_ok=True)
     
     # Configure logging
     logging.basicConfig(
         level=logging.INFO,
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
         handlers=[
-            logging.FileHandler(os.path.join("logs", f"training_log_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.txt")),
+            logging.FileHandler(os.path.join(log_dir, f"training_log_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.txt")),
             logging.StreamHandler()
         ],
         force=True  # Override any existing handlers
@@ -153,9 +153,10 @@ def calculate_dynamic_weights(loss_history, starting_steering_weight, starting_s
     return steering_weight, speed_weight
 
 def train_model(
-    dataset_path, 
-    checkpoint_dir="checkpoints", # Directory to save checkpoints
-    resume_from=None, # Path to resume from checkpoint
+    dataset_path,
+    checkpoint_dir="checkpoints",  # Directory to save checkpoints
+    model_dir="models",  # Directory to save models
+    resume_from=None,  # Path to resume from checkpoint
     window_size=20,  # For 1s of driving data at 20fps
     target_length=1200,  # Length of each segment in frames
     stride=20,  # Non-overlapping windows
@@ -178,7 +179,6 @@ def train_model(
         logging.info(f"Created checkpoint directory: {checkpoint_dir}")
 
     # Create model directory if it doesn't exist
-    model_dir = "models"  # Directory to save models
     if not os.path.exists(model_dir):
         os.makedirs(model_dir)
         logging.info(f"Created model directory: {model_dir}")
@@ -639,10 +639,8 @@ def train_model(
 
 if __name__ == "__main__":
     # Initialize logging
-    logger = setup_logging()
-    
     import argparse
-    
+
     # Set up command-line argument parsing
     parser = argparse.ArgumentParser(description='Train the model in different modes')
     parser.add_argument('--mode', type=str, choices=['train', 'test'], default='train',
@@ -651,8 +649,15 @@ if __name__ == "__main__":
     parser.add_argument('--epochs', type=int, help='Number of epochs to train (default: 30 for train, 5 for test)')
     parser.add_argument('--batch-size', type=int, default=20, help='Batch size for training')
     parser.add_argument('--window-size', type=int, default=20, help='Window size for temporal data')
-    
+    parser.add_argument('--dataset-path', type=str, default=None, help='Path to dataset')
+    parser.add_argument('--checkpoint-dir', type=str, default='checkpoints', help='Directory to store checkpoints')
+    parser.add_argument('--model-dir', type=str, default='models', help='Directory to store trained models')
+    parser.add_argument('--log-dir', type=str, default='logs', help='Directory to store logs')
+
     args = parser.parse_args()
+
+    # Initialize logging using provided log directory
+    logger = setup_logging(args.log_dir)
     
     # Set default epochs based on mode if not specified
     if args.epochs is None:
@@ -669,22 +674,29 @@ if __name__ == "__main__":
         'window_size': args.window_size
     }
     
+    if args.dataset_path is None:
+        if args.mode == 'train':
+            args.dataset_path = "/home/lordphone/my-av/data/raw/comma2k19"
+        else:
+            args.dataset_path = "/home/lordphone/my-av/tests/data"
+
     if args.mode == 'train':
         # Real training mode - use full dataset
         logger.info(f"Starting real training mode with full dataset (epochs: {args.epochs})")
-        
+
         # Check for existing checkpoint
-        checkpoint_dir = "checkpoints"
-        latest_checkpoint_path = os.path.join(checkpoint_dir, 'latest_checkpoint.pth')
+        latest_checkpoint_path = os.path.join(args.checkpoint_dir, 'latest_checkpoint.pth')
         resume_from = latest_checkpoint_path if os.path.exists(latest_checkpoint_path) else None
-        
+
         if resume_from:
             logger.info(f"Resuming training from checkpoint: {resume_from}")
         else:
             logger.info("No checkpoint found. Starting training from scratch.")
-        
+
         train_model(
-            dataset_path="/home/lordphone/my-av/data/raw/comma2k19",
+            dataset_path=args.dataset_path,
+            checkpoint_dir=args.checkpoint_dir,
+            model_dir=args.model_dir,
             resume_from=resume_from,
             **common_params
         )
@@ -692,6 +704,8 @@ if __name__ == "__main__":
         # Test training mode - use test dataset
         logging.info(f"Starting test training mode with test dataset (epochs: {args.epochs})")
         train_model(
-            dataset_path="/home/lordphone/my-av/tests/data",
+            dataset_path=args.dataset_path,
+            checkpoint_dir=args.checkpoint_dir,
+            model_dir=args.model_dir,
             **common_params
         )

--- a/tests/training/test_train.py
+++ b/tests/training/test_train.py
@@ -24,6 +24,8 @@ class TestTrainModel(unittest.TestCase):
             # Call train_model with all the explicit parameters
             model = train_model(
                 dataset_path=self.dataset_path,
+                checkpoint_dir="checkpoints",
+                model_dir="models",
                 window_size=20,  # For 1s of driving data at 20fps
                 target_length=1200,  # Length of each segment in frames
                 stride=20,  # Non-overlapping windows
@@ -39,7 +41,7 @@ class TestTrainModel(unittest.TestCase):
             )
             
             self.assertIsNotNone(model, "Model should not be None after training.")
-            saved_model_path = 'models/best_model.pth'
+            saved_model_path = os.path.join('models', 'best_model.pth')
             self.assertTrue(os.path.exists(saved_model_path), "Best model file should be saved.")
             end_time = time.time()
             print(f"Training completed in {end_time - start_time:.2f} seconds.")


### PR DESCRIPTION
## Summary
- add `dataset_path`, `checkpoint_dir`, `model_dir`, and `log_dir` options
- accept `model_dir` parameter in `train_model`
- update training test to use new arguments
- add `run_training.sh` helper script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*
- `scripts/run_training.sh --help` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `pip install torch --quiet` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684b41cb95fc832797566efa97f523b1