### PR TITLE
Remove hardcoded paths

### DIFF
--- a/scripts/run_training.sh
+++ b/scripts/run_training.sh
@@ -1,12 +1,31 @@
 #!/bin/bash
-# Example script to run training with configurable directories.
-# Update the paths below with your Google Cloud Storage bucket paths or
-# local directories as needed.
+# Simple wrapper to run training. All paths are provided via command line.
 
-DATASET_PATH="/path/to/dataset"
-CHECKPOINT_DIR="/path/to/checkpoints"
-MODEL_DIR="/path/to/models"
-LOG_DIR="/path/to/logs"
+DATASET_PATH=""
+CHECKPOINT_DIR="checkpoints"
+MODEL_DIR="models"
+LOG_DIR="logs"
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dataset-path)
+      DATASET_PATH="$2"; shift 2;;
+    --checkpoint-dir)
+      CHECKPOINT_DIR="$2"; shift 2;;
+    --model-dir)
+      MODEL_DIR="$2"; shift 2;;
+    --log-dir)
+      LOG_DIR="$2"; shift 2;;
+    *)
+      EXTRA_ARGS+=("$1"); shift;;
+  esac
+done
+
+if [[ -z "$DATASET_PATH" ]]; then
+  echo "Usage: $0 --dataset-path DATASET [--checkpoint-dir DIR] [--model-dir DIR] [--log-dir DIR] [additional args]" >&2
+  exit 1
+fi
 
 python3 -m src.training.train \
   --mode train \
@@ -14,4 +33,4 @@ python3 -m src.training.train \
   --checkpoint-dir "$CHECKPOINT_DIR" \
   --model-dir "$MODEL_DIR" \
   --log-dir "$LOG_DIR" \
-  "$@"
+  "${EXTRA_ARGS[@]}"

--- a/src/analysis/raw_data_analysis.py
+++ b/src/analysis/raw_data_analysis.py
@@ -127,4 +127,10 @@ def analyze_dataset(dataset_path):
         print(f"{stat}: {value:.4f}")
     
 if __name__ == "__main__":
-    analyze_dataset("/home/lordphone/my-av/data/raw/comma2k19/")
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Analyze steering and speed data")
+    parser.add_argument("--data-path", type=str, required=True, help="Path to the Comma2k19 dataset")
+    args = parser.parse_args()
+
+    analyze_dataset(args.data_path)

--- a/src/analysis/raw_video_analysis.py
+++ b/src/analysis/raw_video_analysis.py
@@ -283,7 +283,7 @@ if __name__ == "__main__":
     import argparse
     
     parser = argparse.ArgumentParser(description='Analyze video segments in the dataset.')
-    parser.add_argument('--data-path', type=str, default="/home/lordphone/my-av/data/raw/comma2k19/",
+    parser.add_argument('--data-path', type=str, required=True,
                        help='Path to the dataset directory')
     parser.add_argument('--top-n', type=int, default=20,
                        help='Number of videos with fewest frames to display')

--- a/src/evaluation/evaluate.py
+++ b/src/evaluation/evaluate.py
@@ -252,17 +252,13 @@ def create_visualization(frames, steering_preds, speed_preds, ground_truth, outp
     print(f"Visualization saved to {output_path}")
 
 if __name__ == "__main__":
-    # Path to your trained model
-    model_path = "/home/lordphone/my-av/models/best_model.pth"
+    import argparse
 
-    # Path to video (using raw string to handle special characters)
-    video_path = r"/home/lordphone/my-av/data/evaluation/Chunk_1/b0c9d2329ad1606b|2018-07-27--06-03-57/9/video.hevc"
-    
-    # Path to data
-    data_path = "/home/lordphone/my-av/data/evaluation/"
-    
-    # Path to save output video
-    output_path = "/home/lordphone/my-av/data/evaluation/prediction.mp4"
-    
-    # Process the video with predictions and ground truth
-    process_video_with_dataset(model_path, data_path, output_path, video_path)
+    parser = argparse.ArgumentParser(description="Evaluate a trained model and generate a visualization")
+    parser.add_argument("--model-path", type=str, required=True, help="Path to the trained model")
+    parser.add_argument("--data-path", type=str, required=True, help="Path to the evaluation dataset")
+    parser.add_argument("--video-path", type=str, required=True, help="Path to the input video")
+    parser.add_argument("--output-path", type=str, required=True, help="Where to save the visualization")
+    args = parser.parse_args()
+
+    process_video_with_dataset(args.model_path, args.data_path, args.output_path, args.video_path)

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -651,7 +651,7 @@ if __name__ == "__main__":
     parser.add_argument('--batch-size', type=int, default=20, help='Batch size for training')
     parser.add_argument('--window-size', type=int, default=20, help='Window size for temporal data')
     parser.add_argument('--num-workers', type=int, default=2, help='Number of DataLoader worker processes')
-    parser.add_argument('--dataset-path', type=str, default=None, help='Path to dataset')
+    parser.add_argument('--dataset-path', type=str, required=True, help='Path to dataset')
     parser.add_argument('--checkpoint-dir', type=str, default='checkpoints', help='Directory to store checkpoints')
     parser.add_argument('--model-dir', type=str, default='models', help='Directory to store trained models')
     parser.add_argument('--log-dir', type=str, default='logs', help='Directory to store logs')
@@ -675,12 +675,6 @@ if __name__ == "__main__":
         'window_size': args.window_size,
         'num_workers': args.num_workers
     }
-    
-    if args.dataset_path is None:
-        if args.mode == 'train':
-            args.dataset_path = "/home/lordphone/my-av/data/raw/comma2k19"
-        else:
-            args.dataset_path = "/home/lordphone/my-av/tests/data"
 
     if args.mode == 'train':
         # Real training mode - use full dataset


### PR DESCRIPTION
## Summary
- ensure dataset path is always provided to `train.py`
- update helper script `run_training.sh` to require paths via CLI
- remove hardcoded defaults in analysis and evaluation scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_684cc49d8d588327809efdcc17338942