### PR TITLE
Enable environment variable overrides for training

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,14 @@ docker build -t av-model .
 ## Running the container
 
 ```bash
-docker run --gpus all -v $(pwd)/data:/app/data av-model bash scripts/run_training.sh --dataset-path /app/data
+docker run --gpus all \
+  -v $(pwd)/data:/app/data \
+  -e DATASET_PATH=/app/data \
+  -e NUM_WORKERS=4 \
+  -e BATCH_SIZE=32 \
+  av-model
 ```
 
-Adjust the mounted data directory and command line options as needed.
+You can override any training parameter using environment variables or by 
+passing the corresponding command-line flags. Mount the dataset directory as 
+needed for your environment.

--- a/scripts/run_training.sh
+++ b/scripts/run_training.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 # Simple wrapper to run training. All paths are provided via command line.
 
-DATASET_PATH=""
-CHECKPOINT_DIR="checkpoints"
-MODEL_DIR="models"
-LOG_DIR="logs"
+DATASET_PATH="${DATASET_PATH:-}"
+CHECKPOINT_DIR="${CHECKPOINT_DIR:-checkpoints}"
+MODEL_DIR="${MODEL_DIR:-models}"
+LOG_DIR="${LOG_DIR:-logs}"
+NUM_WORKERS="${NUM_WORKERS:-}"
+BATCH_SIZE="${BATCH_SIZE:-}"
 EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -17,20 +19,30 @@ while [[ $# -gt 0 ]]; do
       MODEL_DIR="$2"; shift 2;;
     --log-dir)
       LOG_DIR="$2"; shift 2;;
+    --num-workers)
+      NUM_WORKERS="$2"; shift 2;;
+    --batch-size)
+      BATCH_SIZE="$2"; shift 2;;
     *)
       EXTRA_ARGS+=("$1"); shift;;
   esac
 done
 
 if [[ -z "$DATASET_PATH" ]]; then
-  echo "Usage: $0 --dataset-path DATASET [--checkpoint-dir DIR] [--model-dir DIR] [--log-dir DIR] [additional args]" >&2
+  echo "Usage: $0 --dataset-path DATASET [--checkpoint-dir DIR] [--model-dir DIR] [--log-dir DIR] [--num-workers N] [--batch-size B] [additional args]" >&2
   exit 1
 fi
 
-python3 -m src.training.train \
+CMD=(python3 -m src.training.train \
   --mode train \
   --dataset-path "$DATASET_PATH" \
   --checkpoint-dir "$CHECKPOINT_DIR" \
   --model-dir "$MODEL_DIR" \
-  --log-dir "$LOG_DIR" \
-  "${EXTRA_ARGS[@]}"
+  --log-dir "$LOG_DIR")
+
+[[ -n "$NUM_WORKERS" ]] && CMD+=(--num-workers "$NUM_WORKERS")
+[[ -n "$BATCH_SIZE" ]] && CMD+=(--batch-size "$BATCH_SIZE")
+
+CMD+=("${EXTRA_ARGS[@]}")
+
+"${CMD[@]}"


### PR DESCRIPTION
## Summary
- allow passing training parameters through environment variables
- document using env vars when running the container

## Testing
- `pip install torch --extra-index-url https://download.pytorch.org/whl/cpu`
- `apt-get update`
- `apt-get install -y ffmpeg`
- `pip install ffmpeg-python`
- `pip install numpy`
- `PYTHONPATH=. pytest tests/utils/test_frame_reader.py -k test_get_frame -q` *(fails: FileNotFoundError for test data)*

------
https://chatgpt.com/codex/tasks/task_e_684e3de1dfb483279fbf4dda8b7f8156